### PR TITLE
Support old style definition of "EVP_MD_CTX_destroy".

### DIFF
--- a/include/opensslpp/details/common.h
+++ b/include/opensslpp/details/common.h
@@ -32,7 +32,13 @@ namespace opensslpp
     using KeyPtr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
     using KeyContextPtr = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>;
     using CipherContextPtr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
+#ifndef EVP_MD_CTX_destroy(ctx)
+    // Older versions that do not support "EVP_MD_CTX_free"
+    using DigestContextPtr = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)>;
+#else
+    // Later versions (after 1.1.0-pre2)
     using DigestContextPtr = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+#endif
     using BioMemPtr = std::unique_ptr<BIO, decltype(&BIO_free)>;
 
     template <class BioMethod>


### PR DESCRIPTION
See upstream changes made in 2015:
https://github.com/openssl/openssl/commit/959ed5316c84d0e12ad18acfd40cefe15603ddfb#diff-0a59d5eff295de2df8d6f60a4e419992
https://github.com/openssl/openssl/commit/e0a3a803d93dac94dfd8c7c54445be73f7572032#diff-0a59d5eff295de2df8d6f60a4e419992
https://github.com/openssl/openssl/commit/f8137a62d94c0a5809a4363b7b4aab3adcb8201c#diff-0a59d5eff295de2df8d6f60a4e419992